### PR TITLE
fix: always strip reasoning_effort/output_config when thinking is not enabled

### DIFF
--- a/dsv4_cc_proxy/proxy.py
+++ b/dsv4_cc_proxy/proxy.py
@@ -161,15 +161,38 @@ def _normalize_thinking(data: dict) -> bool:
         return False
 
     thinking_type = thinking_cfg.get("type", "")
+    modified = False
+
+    # Always strip reasoning_effort / output_config — DeepSeek rejects them
+    # when thinking is anything other than "enabled"
+    if thinking_type != "enabled":
+        for key in ("reasoning_effort", "output_config"):
+            val = data.pop(key, None)
+            if val is not None:
+                logger.info("[THINKING] removed %s=%s", key, val)
+                modified = True
+
     if thinking_type in ("enabled", "disabled"):
-        return False
+        if modified:
+            stripped = 0
+            for msg in data.get("messages", []):
+                if msg.get("role") != "assistant":
+                    continue
+                content = msg.get("content", [])
+                if isinstance(content, str):
+                    continue
+                new_content = [
+                    b for b in content
+                    if not (isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking"))
+                ]
+                if len(new_content) != len(content):
+                    stripped += len(content) - len(new_content)
+                    msg["content"] = new_content
+            if stripped:
+                logger.info("[THINKING] disabled mode — stripped %d thinking blocks", stripped)
+        return modified
 
     data["thinking"] = {"type": "disabled"}
-
-    for key in ("reasoning_effort", "output_config"):
-        val = data.pop(key, None)
-        if val is not None:
-            logger.info("[THINKING] removed %s=%s", key, val)
 
     stripped = 0
     for msg in data.get("messages", []):


### PR DESCRIPTION

## 修复说明

### 问题
Claude Code 子代理（WebSearch / WebFetch / Agent / Workflow）发送请求时使用 
`thinking.type: "disabled"`，但请求中同时携带了 `reasoning_effort` 和 `output_config` 字段。

DeepSeek API 要求：若存在 `reasoning_effort` 或 `output_config.effort`，则 `thinking.type` 
必须为 `enabled`，否则返回 HTTP 400：
> thinking options type cannot be disabled when reasoning_effort is set

### 根因
`_normalize_thinking` 函数在 `thinking.type == "disabled"` 时直接 `return False`，跳过了 
`reasoning_effort` / `output_config` 的清理逻辑。

### 修复
当 `thinking.type != "enabled"` 时，始终清理 `reasoning_effort` 和 `output_config`，
不再区分 disabled 与其他类型。

### 触发条件
- `CLAUDE_CODE_EFFORT_LEVEL=max`
- 子代理使用 DeepSeek 模型（如 `deepseek-v4-flash`）

### 已验证
- [x] WebSearch 正常返回结果
- [x] WebFetch 正常抓取网页
- [x] Agent 子代理正常执行
