### PR TITLE
fix: strip reasoning_effort and output_config when thinking.type is disabled

### DIFF
--- a/dsv4_cc_proxy/proxy.py
+++ b/dsv4_cc_proxy/proxy.py
@@ -161,7 +161,20 @@ def _normalize_thinking(data: dict) -> bool:
         return False
 
     thinking_type = thinking_cfg.get("type", "")
-    if thinking_type in ("enabled", "disabled"):
+
+    # When thinking is disabled, remove all conflicting effort params.
+    # Fixes "thinking options type cannot be disabled when reasoning_effort is set"
+    # Claude Code v2.1.166+ sends output_config.effort with thinking:disabled for subagents.
+    if thinking_type == "disabled":
+        removed_any = False
+        for key in ("reasoning_effort", "output_config"):
+            if key in data:
+                data.pop(key)
+                removed_any = True
+                logger.info("[THINKING] disabled: removed %s", key)
+        return removed_any
+
+    if thinking_type == "enabled":
         return False
 
     data["thinking"] = {"type": "disabled"}


### PR DESCRIPTION
## Problem

Claude Code v2.1.166+ breaks subagent creation with DeepSeek V4 models. When spawning subagents, Claude Code sends:

```json
{
  "thinking": { "type": "disabled" },
  "output_config": { "effort": "medium" }
}
```

DeepSeek API rejects this with:
> `API Error: 400 thinking options type cannot be disabled when reasoning_effort is set`

## Root Cause

`_normalize_thinking()` returned `False` immediately when `thinking_type` was `"disabled"`, without stripping the conflicting `reasoning_effort` and `output_config` params. This meant requests already having `thinking.type: disabled` (which Claude Code sends for subagents) passed through unmodified, triggering DeepSeek's 400 error.

## Fix

When `thinking.type == "disabled"`, actively remove both `reasoning_effort` and `output_config` before forwarding to DeepSeek.

## Related Issues
- anthropics/claude-code#65863
- deepseek-ai/DeepSeek-V3#1397
- deepseek-ai/awesome-deepseek-agent#193

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)